### PR TITLE
Adding params to player describe definition

### DIFF
--- a/lib/player.lua
+++ b/lib/player.lua
@@ -68,6 +68,7 @@ end
 -- supports_bend (does this voice support pitch bend?)
 -- supports_slew (does this voice support set_slew?)
 -- note_mod_targets (optional list of targets for "note mod")
+-- params (optional list of parameter IDs for lookup use in scripts)
 function player:describe()
     return {
         name = "none",
@@ -76,6 +77,7 @@ function player:describe()
         modulate_description = "unsupported",
         note_mod_targets = {},
         voice_mod_tarets = {},
+        params = {},
     }
 end
 


### PR DESCRIPTION
Defining a list of the available param IDs in the player's describe function would be helpful for scripts that which to look up the param directly to modify it's value. See proposed implementation in the [emplaitress repo](https://github.com/sixolet/emplaitress/pull/3). If there's a more idiomatic way to do this in mind, great! I might have just missed it or misunderstood. 