### PR TITLE
minor fixes

### DIFF
--- a/lib/nb.lua
+++ b/lib/nb.lua
@@ -134,7 +134,7 @@ function nb:add_param(param_id, param_name)
     local p = params:lookup_param(param_id)
     local initialized = false
     function p:get_player()
-        local name = params:get(string_param_id)
+        local name = tostring(params:get(string_param_id))
         if name == "none" then
             if p.player ~= nil then
                 p.player:count_down()
@@ -161,7 +161,7 @@ function nb:add_param(param_id, param_name)
         initialized = true
     end, p)
     params:set_action(string_param_id, function(name_param)
-        local i = names_inverted[params:get(string_param_id)]
+        local i = names_inverted[tostring(params:get(string_param_id))]
         if i ~= nil then
             -- silently set the interface param.
             params:set(param_id, i, true)

--- a/lib/nb.lua
+++ b/lib/nb.lua
@@ -2,14 +2,6 @@ local mydir = debug.getinfo(1).source:match("@?" .. _path.code .. "(.*/)")
 local player_lib = include(mydir .. "player")
 local nb = {}
 
-if note_players == nil then
-    note_players = {}
-end
-
--- note_players is a global that you can add note-players to from anywhere before
--- you call nb:add_param.
-nb.players = note_players -- alias the global here. Helps with standalone use.
-
 nb.none = player_lib:new()
 
 -- Set this before init() to affect the number of voices added for some mods.
@@ -92,7 +84,7 @@ local function add_midi_players()
                             mod_d = "cc " .. params:get("midi_modulation_cc_" .. i .. '_' .. j)
                         end
                         return {
-                            name = "v.name",
+                            name = v.name,
                             supports_bend = true,
                             supports_slew = false,
                             note_mod_targets = { "pressure" },
@@ -109,6 +101,14 @@ end
 
 -- Call from your init method.
 function nb:init()
+    if note_players == nil then
+        note_players = {}
+    end
+    
+    -- note_players is a global that you can add note-players to from anywhere before
+    -- you call nb:add_param.
+    nb.players = note_players -- alias the global here. Helps with standalone use.
+
     nb_player_refcounts = {}
     add_midi_players()
     self:stop_all()
@@ -122,7 +122,9 @@ function nb:add_param(param_id, param_name)
     for name, _ in pairs(note_players) do
         table.insert(names, name)
     end
-    table.sort(names)
+    table.sort(names, function(a, b)
+        return string.lower(a) < string.lower(b)
+    end)
     table.insert(names, 1, "none")
     local names_inverted = tab.invert(names)
     params:add_option(param_id, param_name, names, 1)

--- a/lib/player.lua
+++ b/lib/player.lua
@@ -76,7 +76,7 @@ function player:describe()
         supports_slew = false,
         modulate_description = "unsupported",
         note_mod_targets = {},
-        voice_mod_tarets = {},
+        voice_mod_targets = {},
         params = {},
     }
 end

--- a/nb.lua
+++ b/nb.lua
@@ -51,3 +51,7 @@ function grid_redraw()
     end
     g:refresh()
 end
+
+function cleanup()
+    nb:stop_all()
+end


### PR DESCRIPTION
- moved creation of note_players and aliasing of nb.players to nb:init() to resolve error launching nb.lua demo script multiple times.
- fixed issue with description>>name field not being populated with MIDI v port name
- fixed typo in `voice_mod_targets`
- modified sorting of players to handle uppercase names
- added nb:stop_all() to cleanup() fn in nb.lua
- fix for system issue with pset loading breaking text param